### PR TITLE
Changed map-function so that ClassFinder can search for class-files in g...

### DIFF
--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/ClassFinder.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/ClassFinder.java
@@ -167,8 +167,8 @@ public class ClassFinder {
     private List<Class> exctractClasses(final String packageDir, List<String> files) {
         final String seperator = CLASS_PROJECT_SEPERATOR.concat(File.separator);
         return files.parallelStream()
-                .map(dir -> dir.substring((dir.lastIndexOf(seperator) + CLASS_PROJECT_SEPERATOR_LENGTH), dir.length()))
                 .filter(classDir -> classDir.contains(packageDir))
+                .map(dir -> dir.substring(dir.indexOf(packageDir)))
                 .map(subDir -> subDir.replace(File.separator, CLASS_DOT))
                 .map(className -> className.substring(0, className
                         .lastIndexOf(CLASS_FILE)))


### PR DESCRIPTION
Changed map-function so that ClassFinder can search for class-files in gradle project.
Gradle keeps them into build/classes/production/PROJECT_NAME/full/package/name folder.