### PR TITLE
Rejuvenate log levels

### DIFF
--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/component/ASubComponent.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/component/ASubComponent.java
@@ -90,7 +90,7 @@ public abstract class ASubComponent  implements
         try {
             this.incomingMessage.put(action);
         } catch (final InterruptedException e) {
-            this.componentLogger.info("massage put failed:");
+            this.componentLogger.warning("massage put failed:");
             //TODO handle exception global
         }
 

--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/handler/DefaultErrorDialogHandler.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/handler/DefaultErrorDialogHandler.java
@@ -44,7 +44,7 @@ public class DefaultErrorDialogHandler extends AErrorDialogHandler {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         e.printStackTrace(pw);
-        logger.log(Level.INFO,sw.toString());
+        logger.log(Level.FINEST,sw.toString());
         return new DefaultErrorDialog("Error Pane",sw.toString());
     }
 }

--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/WorkbenchUtil.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/WorkbenchUtil.java
@@ -174,7 +174,7 @@ public class WorkbenchUtil {
         final String id = perspectiveAnnotation.id();
         if (id == null) throw new IllegalArgumentException("no perspective id set");
         initContext(InternalContext.class.cast(perspective.getContext()), parentId, id, perspectiveAnnotation.active());
-        LOGGER.fine("register perspective with annotations : "
+        LOGGER.finer("register perspective with annotations : "
                 + perspectiveAnnotation.id());
         initDeclarativePerspectiveParts(perspective, perspectiveAnnotation);
         initLocaleAttributes(perspective, perspectiveAnnotation);


### PR DESCRIPTION
 Here's a reissue of https://github.com/JacpFX/JacpFX/pull/71 with a new version of our tool. The tool made fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: 14c2a4c332c6d63f7d86d26b899011ca23715996

